### PR TITLE
Delete .bat

### DIFF
--- a/clean.bat
+++ b/clean.bat
@@ -1,4 +1,0 @@
-FOR /F "tokens=*" %%G IN ('DIR /B /AD /S packages') DO RMDIR /S /Q "%%G"
-FOR /F "tokens=*" %%G IN ('DIR /B /AD /S bin') DO RMDIR /S /Q "%%G"
-FOR /F "tokens=*" %%G IN ('DIR /B /AD /S obj') DO RMDIR /S /Q "%%G"
-FOR /F "tokens=*" %%G IN ('DIR /B /AD /S node_modules') DO RMDIR /S /Q "%%G"


### PR DESCRIPTION
Borrado archivo .bat el cual se empleaba para limpiar el proyecto antes de sincronizar a github